### PR TITLE
(GH16)  Fixtures should use `source` not `project_page`

### DIFF
--- a/lib/generate_puppetfile/bin.rb
+++ b/lib/generate_puppetfile/bin.rb
@@ -244,9 +244,9 @@ fixtures:
       module_directories.each do |module_directory|
         name = File.basename(module_directory)
         file = File.read("#{module_directory}/metadata.json")
-        project_page = (JSON.parse(file))["project_page"]
-        fixtures_data += "    #{name}: #{project_page}\n"
-        puts "Found a module '#{name}' with a project page of #{project_page}." if @options[:debug]
+        source = (JSON.parse(file))["source"]
+        fixtures_data += "    #{name}: #{source}\n"
+        puts "Found a module '#{name}' with a project page of #{source}." if @options[:debug]
       end unless module_directories == []
 
       fixtures_data

--- a/lib/generate_puppetfile/version.rb
+++ b/lib/generate_puppetfile/version.rb
@@ -1,3 +1,3 @@
 module GeneratePuppetfile
-  VERSION = '0.9.5'
+  VERSION = '0.9.6'
 end


### PR DESCRIPTION
  Released in version 0.9.6.
Closes #16