### PR TITLE
Version 0.9.7

### DIFF
--- a/generate-puppetfile.gemspec
+++ b/generate-puppetfile.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.homepage    = 'https://github.com/rnelson0/puppet-generate-puppetfile'
   s.license     = 'MIT'
 
-  s.add_development_dependency 'rake', '~> 10'
+  s.add_development_dependency 'rake'
   s.add_development_dependency 'rspec', '~> 3'
   s.add_development_dependency 'rspec-its', '~> 1'
   s.add_development_dependency 'json', '~> 1'

--- a/lib/generate_puppetfile/version.rb
+++ b/lib/generate_puppetfile/version.rb
@@ -1,3 +1,3 @@
 module GeneratePuppetfile
-  VERSION = '0.9.6'
+  VERSION = '0.9.7'
 end

--- a/spec/generate_puppetfile/bin_spec.rb
+++ b/spec/generate_puppetfile/bin_spec.rb
@@ -34,8 +34,19 @@ describe GeneratePuppetfile::Bin do
   end
 
   context 'when running with one module on the CLI' do
-    let(:args) { 'rnelson0/certs' }
+    let :args do
+      'rnelson0/certs'
+    end
 
     its(:exitstatus) { is_expected.to eq(0) }
+  end
+
+  context 'when puppet is not available' do
+    let :args do
+      'rnelson0/certs'
+    end
+    before { ENV['PATH'] = '/dne' }
+
+    its(:exitstatus) { is_expected.to eq(1) }
   end
 end


### PR DESCRIPTION
  Provide a graceful error message when 'puppet' is not found, and rspec test. (fixes #19)
  Filter out comments from generate-puppetfile to prevent duplicates. (fixes #20)
  Unpin rake version
  Debug info: print the PMT commands