### PR TITLE
Require Ruby 2.0.0 due to mkmf methods that are not present in stdlib <2.0.0.

### DIFF
--- a/generate-puppetfile.gemspec
+++ b/generate-puppetfile.gemspec
@@ -18,7 +18,7 @@ Gem::Specification.new do |s|
   s.files                += Dir.glob('lib/**/*')
   s.homepage              = 'https://github.com/rnelson0/puppet-generate-puppetfile'
   s.license               = 'MIT'
-  s.required_ruby_version = '>= 1.9.3'
+  s.required_ruby_version = '>= 2.0.0'
 
   s.add_development_dependency 'rake'
   s.add_development_dependency 'rspec', '~> 3'

--- a/lib/generate_puppetfile/version.rb
+++ b/lib/generate_puppetfile/version.rb
@@ -1,3 +1,3 @@
 module GeneratePuppetfile
-  VERSION = '0.9.8'.freeze
+  VERSION = '0.9.9'.freeze
 end


### PR DESCRIPTION
Closes #30 