### PR TITLE
Format the Puppetfile into columns

### DIFF
--- a/lib/generate_puppetfile/bin.rb
+++ b/lib/generate_puppetfile/bin.rb
@@ -294,9 +294,13 @@ Your Puppetfile has been generated. Copy and paste between the markers:
 
     # Public: generate the list of modules in Puppetfile format from the @workspace
     def generate_forge_module_output
+      return '' if @module_data.empty?
+
+      max_length    = @module_data.keys.max_by {|mod| mod.length}.length + 3 # room for extra chars
       module_output = ''
-      @module_data.keys.each do |modulename|
-        module_output += "mod '#{modulename}', '#{@module_data[modulename]}'\n"
+
+      @module_data.each do |modulename, version|
+        module_output += sprintf("mod %-#{max_length}s '%s'\n", "'#{modulename}',", version)
       end
       module_output
     end


### PR DESCRIPTION
Example usage:

```
root@localhost:~ # generate-puppetfile pltraining/userprefs

Installing modules. This may take a few minutes.


Your Puppetfile has been generated. Copy and paste between the markers:

=======================================================================
forge 'http://forge.puppetlabs.com'

# Modules discovered by generate-puppetfile
mod 'pltraining/userprefs',  '1.0.17'
mod 'puppetlabs/chocolatey', '3.0.0'
mod 'puppetlabs/powershell', '2.1.2'
mod 'puppetlabs/registry',   '1.1.4'
mod 'puppetlabs/stdlib',     '4.17.1'
mod 'stahnma/epel',          '1.2.2'
=======================================================================
```