### PR TITLE
Sort fixtures.yml, add --latest-versions flag, misc bug fixes

### DIFF
--- a/lib/generate_puppetfile/bin.rb
+++ b/lib/generate_puppetfile/bin.rb
@@ -11,11 +11,11 @@ require 'uri'
 module GeneratePuppetfile
   # Internal: The Bin class contains the logic for calling generate_puppetfile at the command line
   class Bin
-    Module_Regex        = %r{^\s*mod ['"]([a-z0-9_]+\/[a-z0-9_]+)['"](,\s+['"](\d+\.\d+\.\d+)['"])?\s*$}i
-    Repository_Regex    = %r{^\s*mod\s+['"](\w+)['"]\s*,\s*$}i
-    Location_Only_Regex = %r{^\s+:git\s+=>\s+['"](\S+)['"]\s*$}i
-    Location_Plus_Regex = %r{^\s+:git\s+=>\s+['"](\S+)['"]\s*,\s*$}i
-    Type_ID_Regex       = %r{^\s+:(\w+)\s+=>\s+['"](\S+)['"]\s*$}i
+    Module_Regex        = %r{^\s*mod ['"]([a-z0-9_]+\/[a-z0-9_]+)['"](,\s+['"](\d+\.\d+\.\d+)['"])?\s*(?:#.*)?$}i
+    Repository_Regex    = %r{^\s*mod\s+['"](\w+)['"]\s*,\s*(?:#.*)?$}i
+    Location_Only_Regex = %r{^\s+:git\s+=>\s+['"](\S+)['"]\s*(?:#.*)?$}i
+    Location_Plus_Regex = %r{^\s+:git\s+=>\s+['"](\S+)['"]\s*,\s*(?:#.*)?$}i
+    Type_ID_Regex       = %r{^\s+:(\w+)\s+=>\s+['"](\S+)['"]\s*(?:#.*)?$}i
     Forge_Regex         = %r{^forge}
     Blanks_Regex        = %r{^\s*$}
     Comments_Regex      = %r{^\s*#}

--- a/lib/generate_puppetfile/bin.rb
+++ b/lib/generate_puppetfile/bin.rb
@@ -11,7 +11,7 @@ require 'uri'
 module GeneratePuppetfile
   # Internal: The Bin class contains the logic for calling generate_puppetfile at the command line
   class Bin
-    Module_Regex        = %r{^\s*mod ['"]([a-z0-9_]+\/[a-z0-9_]+)['"](,\s+['"](\d+\.\d+\.\d+)['"])?\s*(?:#.*)?$}i
+    Module_Regex        = %r{^\s*mod ['"]([a-z0-9_]+[/-][a-z0-9_]+)['"](,\s+['"](\d+\.\d+\.\d+)['"])?\s*(?:#.*)?$}i
     Repository_Regex    = %r{^\s*mod\s+['"](\w+)['"]\s*,\s*(?:#.*)?$}i
     Location_Only_Regex = %r{^\s+:git\s+=>\s+['"](\S+)['"]\s*(?:#.*)?$}i
     Location_Plus_Regex = %r{^\s+:git\s+=>\s+['"](\S+)['"]\s*,\s*(?:#.*)?$}i
@@ -486,7 +486,7 @@ forge 'https://forge.puppet.com'
       unless @module_data.empty?
         fixtures_data += "  forge_modules:\n"
         @module_data.keys.each do |modulename|
-          shortname = modulename.split('/')[1]
+          shortname = modulename.split(/[\/-]/)[1]
           version = @module_data[modulename] 
           data = <<-EOF
     #{shortname}:

--- a/lib/generate_puppetfile/bin.rb
+++ b/lib/generate_puppetfile/bin.rb
@@ -476,7 +476,7 @@ forge 'https://forge.puppet.com'
     #{name}:
       repo: "#{location}"
           EOF
-          data += "      #{type}: \"#{id}\"\n" if (type && id)
+          data += "      #{type}: \"#{id}\"\n" unless @options[:latest_versions] || !type || !id
 
           fixtures_data += data
         end
@@ -491,9 +491,8 @@ forge 'https://forge.puppet.com'
           data = <<-EOF
     #{shortname}:
       repo: "#{modulename}"
-      ref: "#{version}"
           EOF
-          data.gsub!(/^ *ref.*$\n/, '') unless version != nil
+          data += "      ref: \"#{version}\"\n" unless @options[:latest_versions] || version.nil?
 
           fixtures_data += data
         end

--- a/lib/generate_puppetfile/bin.rb
+++ b/lib/generate_puppetfile/bin.rb
@@ -435,6 +435,7 @@ forge 'https://forge.puppet.com'
         paths = modulepath.split(':').delete_if { |path| path =~ /^\$/ }
         paths.each do |path|
           Dir["#{path}/*"].each do |module_location|
+            next unless File.directory?(module_location)
             module_name = File.basename(module_location)
             module_path = module_location
             symlinks << {

--- a/lib/generate_puppetfile/bin.rb
+++ b/lib/generate_puppetfile/bin.rb
@@ -11,11 +11,11 @@ require 'uri'
 module GeneratePuppetfile
   # Internal: The Bin class contains the logic for calling generate_puppetfile at the command line
   class Bin
-    Module_Regex        = %r{^\s*mod ['\"]([a-z0-9_]+\/[a-z0-9_]+)['\"](,\s+['\"](\d+\.\d+\.\d+)['\"])?\s*$}i
-    Repository_Regex    = %r{^\s*mod\s+['\"](\w+)['\"]\s*,\s*$}i
-    Location_Only_Regex = %r{^\s+:git\s+=>\s+['\"](\S+)['\"]\s*$}i
-    Location_Plus_Regex = %r{^\s+:git\s+=>\s+['\"](\S+)['\"]\s*,\s*$}i
-    Type_ID_Regex       = %r{^\s+:(\w+)\s+=>\s+['\"](\S+)['\"]\s*$}i
+    Module_Regex        = %r{^\s*mod ['"]([a-z0-9_]+\/[a-z0-9_]+)['"](,\s+['"](\d+\.\d+\.\d+)['"])?\s*$}i
+    Repository_Regex    = %r{^\s*mod\s+['"](\w+)['"]\s*,\s*$}i
+    Location_Only_Regex = %r{^\s+:git\s+=>\s+['"](\S+)['"]\s*$}i
+    Location_Plus_Regex = %r{^\s+:git\s+=>\s+['"](\S+)['"]\s*,\s*$}i
+    Type_ID_Regex       = %r{^\s+:(\w+)\s+=>\s+['"](\S+)['"]\s*$}i
     Forge_Regex         = %r{^forge}
     Blanks_Regex        = %r{^\s*$}
     Comments_Regex      = %r{^\s*#}

--- a/lib/generate_puppetfile/bin.rb
+++ b/lib/generate_puppetfile/bin.rb
@@ -456,14 +456,14 @@ forge 'https://forge.puppet.com'
       fixtures_data = "fixtures:\n"
       if symlinks
         fixtures_data += "  symlinks:\n"
-        symlinks.each do |symlink|
+        symlinks.sort_by!{|symlink| symlink[:name]}.each do |symlink|
           fixtures_data += "    #{symlink[:name]}: #{symlink[:path]}\n"
         end
       end
 
       unless @repository_data.empty?
         fixtures_data += "  repositories:\n"
-        @repository_data.each do |repodata|
+        @repository_data.sort_by!{|repo| repo[:name]}.each do |repodata|
           # Each repository has two or  pieces of data
           #   Mandatory: the module name, the URI/location
           #   Optional: the type (ref, branch, commit, etc.) and ID (tag, branch name, commit hash, etc.)
@@ -485,7 +485,7 @@ forge 'https://forge.puppet.com'
 
       unless @module_data.empty?
         fixtures_data += "  forge_modules:\n"
-        @module_data.keys.each do |modulename|
+        @module_data.keys.sort_by!{|mod| mod.split(/[\/-]/)[1]}.each do |modulename|
           shortname = modulename.split(/[\/-]/)[1]
           version = @module_data[modulename] 
           data = <<-EOF

--- a/lib/generate_puppetfile/optparser.rb
+++ b/lib/generate_puppetfile/optparser.rb
@@ -36,6 +36,10 @@ module GeneratePuppetfile
           options[:modulename] = name
         end
 
+        opts.on('-l', '--latest-versions', "Use latest version of forge modules and default branch of repository modules in .fixtures.yml") do |name|
+          options[:latest_versions] = true
+        end
+
         opts.on('-s', '--silent', 'Run in silent mode. Supresses all non-debug output. Adds the -c flag automatically.') do
           options[:silent] = true
           options[:create_puppetfile] = true

--- a/spec/generate_puppetfile/bin_spec.rb
+++ b/spec/generate_puppetfile/bin_spec.rb
@@ -201,12 +201,12 @@ describe GeneratePuppetfile::Bin do
     it 'should add the non-forge modules to the fixtures' do
       fixture_data = <<EOF
   repositories:
-    ntp:
-      repo: "https://github.com/example-ntp.git"
-      tag: "0.1.1"
     motd:
       repo: "https://github.com/example-motd.git"
       tag: "1.0.0"
+    ntp:
+      repo: "https://github.com/example-ntp.git"
+      tag: "0.1.1"
 EOF
       expect(File.read('./.fixtures.yml')).to include(fixture_data)
     end


### PR DESCRIPTION
- Enable support for 'author-name' module syntax in the control repo `Puppetfile`
- Allow trailing comments in `Puppetfile` module lines
- Sort modules by name in `.fixtures.yml`
- Only include directories when adding `.fixtures.yml` symlinks
- Add a `--latest-versions` flag to cause `.fixtures.yml` to use the latest version of forge modules and the default branch of repository modules. The `--latest-versions` flag can be helpful for testing whether new versions of modules introduce spec test failures.