### PR TITLE
# update readme for pdk & bolt use cases

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,6 +100,39 @@ mod 'lab_config',
   :git => 'git@github.com:puppetinabox/lab_config.git'
 =======================================================================
 ```
+#### extending puppet modules & bolt projects 
+
+Due to the nature of the generate-puppetfile gem it makes an excellent tool for developing the Puppetfile for [bolt projects]( https://puppet.com/docs/bolt/latest/bolt_project_directories.html). Seeing the simplest way to create a Bolt project is with the Puppet PDK this approach extends that use case. Add the following to your `.sync.yml` in a pdk managed module and run `pdk update`.zd
+
+```
+Gemfile:
+  optional:
+    ':development':
+      - gem: 'generate-puppetfile'
+        version: '~> 1.0
+```
+
+Addition the following add to `/rakelib/generate_puppetfile.rake` will add a task to the experimental `pdk bundle` feature you can then use `pdk bundle exec rake generate_puppetfile` to generate the puppetfile based on the modules metadata.  
+
+```
+require 'json'
+
+desc 'generate puppetfile'
+task :generate_puppetfile, [:mod] do |t, args| 
+    args.with_defaults(:mod => JSON.parse(File.read('metadata.json'))['name'])
+    sh "generate-puppetfile -c  #{args.mod}"
+end
+```
+Additionally add the following to `/rakelib/generate_fixturesfile.rake` will add a task to the experimental `pdk bundle` feature you can then use `pdk bundle exec rake generate_fixturesfile` to generate the `.fixtures.yaml` based on the module metadata to aid in testing with the `pdk test` feature.  
+
+```
+desc 'generate fixtures'
+task :generate_fixturesfile do |t| 
+    mod = JSON.parse(File.read('metadata.json'))['name']
+    sh "generate-puppetfile -f -p ./Puppetfile #{mod} --fixtures-only -m #{mod}"
+end
+```
+
 
 ## Limitations
 

--- a/README.md
+++ b/README.md
@@ -112,7 +112,7 @@ Gemfile:
         version: '~> 1.0
 ```
 
-Addition the following add to `/rakelib/generate_puppetfile.rake` will add a task to the experimental `pdk bundle` feature you can then use `pdk bundle exec rake generate_puppetfile` to generate the puppetfile based on the modules metadata.  
+Add the following to `/rakelib/generate_puppetfile.rake` to create a rake target for the experimental `pdk bundle` feature. You can then use `pdk bundle exec rake generate_puppetfile` to generate the puppetfile based on the modules metadata.
 
 ```
 require 'json'

--- a/README.md
+++ b/README.md
@@ -123,7 +123,7 @@ task :generate_puppetfile, [:mod] do |t, args|
     sh "generate-puppetfile -c  #{args.mod}"
 end
 ```
-Additionally add the following to `/rakelib/generate_fixturesfile.rake` will add a task to the experimental `pdk bundle` feature you can then use `pdk bundle exec rake generate_fixturesfile` to generate the `.fixtures.yaml` based on the module metadata to aid in testing with the `pdk test` feature.  
+Add the following to `/rakelib/generate_fixturesfile.rake` to create a rake target for the experimental `pdk bundle` feature. You can then use `pdk bundle exec rake generate_fixturesfile` to generate the `.fixtures.yaml` based on the module metadata to aid in testing with the `pdk test` feature.
 
 ```
 desc 'generate fixtures'


### PR DESCRIPTION
This pull request adds a section for using the gem with pdk and `pdk update` with code snippets
 it also provides two rake tasks that are supported by the `pdk bundle` command.
the tasks parse a valid metadata to create module specific puppetfile for bolt projects
and module specific fixtures for testing puppetmodules.